### PR TITLE
Refactoring temporary json file concatenation

### DIFF
--- a/abstar/core/abstar.py
+++ b/abstar/core/abstar.py
@@ -448,7 +448,6 @@ def concat_outputs(input_file, temp_output_file_dicts, output_dir, args):
                 for temp_file in temp_files:
                     with open(temp_file, "rb") as f:
                         shutil.copyfileobj(f, out_file, length=16 * 1024**2)  # Increasing buffer size to 16MB for faster transfer
-                    out_file.write(b"\n")
             # For file formats with headers, only keep headers from the first file
             if output_type in ['imgt', 'tabular', 'airr']:
                 for i, temp_file in enumerate(temp_files):

--- a/abstar/core/abstar.py
+++ b/abstar/core/abstar.py
@@ -447,7 +447,7 @@ def concat_outputs(input_file, temp_output_file_dicts, output_dir, args):
             if output_type == 'json':
                 for temp_file in temp_files:
                     with open(temp_file, "rb") as f:
-                        shutil.copyfileobj(f, out_file, length=1024**3)  # Increasing buffer size to 1GB for faster transfer
+                        shutil.copyfileobj(f, out_file, length=16 * 1024**2)  # Increasing buffer size to 16MB for faster transfer
             # For file formats with headers, only keep headers from the first file
             if output_type in ['imgt', 'tabular', 'airr']:
                 for i, temp_file in enumerate(temp_files):

--- a/abstar/core/abstar.py
+++ b/abstar/core/abstar.py
@@ -457,7 +457,6 @@ def concat_outputs(input_file, temp_output_file_dicts, output_dir, args):
                                 out_file.write(line)
                             elif j >= 1:
                                 out_file.write(line)
-                        out_file.write('\n')
         if args.parquet and output_type not in PARQUET_INCOMPATIBLE:
             logger.info('Converting concatenated output to parquet format')
             pname = oprefix + '.parquet'

--- a/abstar/core/abstar.py
+++ b/abstar/core/abstar.py
@@ -43,6 +43,7 @@ import tempfile
 import time
 import traceback
 import warnings
+import shutil
 
 from Bio import SeqIO
 
@@ -440,15 +441,13 @@ def concat_outputs(input_file, temp_output_file_dicts, output_dir, args):
         if args.gzip:
             ohandle = gzip.open(ofile + ".gz", 'wb')
         else:
-            ohandle = open(ofile, 'w')
+            ohandle = open(ofile, 'wb')
         with ohandle as out_file:
             # JSON-formatted files don't have headers, so we don't worry about it
             if output_type == 'json':
                 for temp_file in temp_files:
-                    with open(temp_file) as f:
-                        for line in f:
-                            out_file.write(line)
-                    out_file.write('\n')
+                    with open(temp_file, "rb") as f:
+                        shutil.copyfileobj(f, out_file, length=1024**3)  # Increasing buffer size to 1GB for faster transfer
             # For file formats with headers, only keep headers from the first file
             if output_type in ['imgt', 'tabular', 'airr']:
                 for i, temp_file in enumerate(temp_files):

--- a/abstar/core/abstar.py
+++ b/abstar/core/abstar.py
@@ -448,6 +448,7 @@ def concat_outputs(input_file, temp_output_file_dicts, output_dir, args):
                 for temp_file in temp_files:
                     with open(temp_file, "rb") as f:
                         shutil.copyfileobj(f, out_file, length=16 * 1024**2)  # Increasing buffer size to 16MB for faster transfer
+                    out_file.write(b"\n")
             # For file formats with headers, only keep headers from the first file
             if output_type in ['imgt', 'tabular', 'airr']:
                 for i, temp_file in enumerate(temp_files):

--- a/abstar/utils/output.py
+++ b/abstar/utils/output.py
@@ -587,6 +587,7 @@ def write_output(output_dict, output_dir, output_prefix):
         output_file = os.path.join(subdir, output_name)
         with open(output_file, 'w') as f:
             f.write('\n'.join(output_dict[fmt]))
+            f.write("\n")
         output_file_dict[fmt] = output_file
     return output_file_dict
 


### PR DESCRIPTION
The current implementation reads JSON files line by line and appends them to a single output file in string mode. The following optimisations were made in this edit:

- Calling `shutil.copyfileobj` to append contents of one file to another in binary mode, in chunks of 16MB at a time
- Abstar results exist as a dictionary `outputs_dict`, with a key for each format type. For JSON files, for example, results are in the form of a list in `outputs_dict["json"]`. The current implementation seeks to write this list to file by joining the string with `f.write('\n'.join(output_dict[fmt]))`. However, this only creates a new line between items in the list. The current method gets around this by adding a new line in `abstar/core/abstar.py::concat_outputs` for each of `if output_type == 'json':` and `if output_type in ['imgt', 'tabular', 'airr']:` conditions. Editing `abstar/utils/output.py::write_output` directly instead not only avoids duplication but also allows for strict appending of contents from files using `shutil.copyfileobj`, which would otherwise append the contents of file 2 to the end of the last line of file 1.