### PR TITLE
Remove specifying maxtasksperchild when creating multiprocess pool resource.

### DIFF
--- a/abstar/core/abstar.py
+++ b/abstar/core/abstar.py
@@ -785,7 +785,7 @@ def _run_jobs_singlethreaded(files, output_dir, log_dir, file_format, args):
 
 
 def _run_jobs_via_multiprocessing(files, output_dir, log_dir, file_format, args):
-    p = Pool(processes=args.num_cores, maxtasksperchild=50)
+    p = Pool(processes=args.num_cores)
     async_results = []
     if args.verbose:
         update_progress(0, len(files))


### PR DESCRIPTION
Abstar randomly hangs at the end of the multi-threaded process. One of the reasons might be that specifying `maxtasksperchild` when creating python's `multiprocessing`'s `pool` resource while also in a Linux system where the default `startmethod` is `fork` is memory and thread unsafe. This leads to a RACE condition where the `multiprocessing` system is not able to safely end resources when the pool resource is terminated, resulting in an indefinite wait for signal from the child process.